### PR TITLE
Switch to new companies data source

### DIFF
--- a/pyasx/config.yml
+++ b/pyasx/config.yml
@@ -1,11 +1,11 @@
 ---
 
 # Endpoint providing CSV of listed companies and their tickers
-asx_companies_csv: https://www.asx.com.au/asx/research/ASXListedCompanies.csv
+asx_companies_csv: https://asx.api.markitdigital.com/asx-research/1.0/companies/directory/file
 
 # Endpoint providing XLS spreadsheet of all listed securities and their tickers
 asx_securities_tsv: https://www.asx.com.au/programs/ISIN.xls
-    # NOTE the extension is xls but the file is actuall tab separated
+    # NOTE the extension is xls but the file is actually tab separated
 
 # Endpoint to pull individual companies data
 asx_company_json: https://www.asx.com.au/asx/1/company/%s?fields=primary_share,latest_annual_reports,last_dividend,primary_share.indices

--- a/pyasx/data/companies.py
+++ b/pyasx/data/companies.py
@@ -48,21 +48,22 @@ def get_listed_companies():
 
         # rewind the temp stream and convert it to an iterator for csv.reader below
         temp_stream.seek(0)
-        temp_iter = iter(temp_stream.readline, '');
+        temp_iter = iter(temp_stream.readline, '')
 
-        # skip the first 3 rows of the CSV as they are header rows
-        for i in range(0, 3):
-            next(temp_iter)
+        # skip the first row of the CSV as it is a header row
+        next(temp_iter)
 
         # read the stream back in & parse out the company details from each row
         for row in csv.reader(temp_iter):
 
-            name, ticker, gics = row
+            ticker, name, listing_date, gics, market_cap = row
 
             all_listed_companies.append({
-                'name': name,
                 'ticker': ticker,
-                'gics_industry': gics
+                'name': name,
+                'listing_date': listing_date,
+                'gics_industry': gics,
+                'market_cap': market_cap
             })
 
     return all_listed_companies

--- a/pyasx/tests/data/companies.py
+++ b/pyasx/tests/data/companies.py
@@ -32,16 +32,19 @@ class CompaniesTest(unittest.TestCase):
 
         self.get_listed_companies_data = [
             # just the first ones from the file to test with
-            [ "MOQ LIMITED", "MOQ", "Software & Services" ],
-            [ "1-PAGE LIMITED", "1PG", "Software & Services" ],
-            [ "1300 SMILES LIMITED", "ONT", "Health Care Equipment & Services" ],
-            [ "1ST GROUP LIMITED", "1ST", "Health Care Equipment & Services" ],
+            # the fields for Pharmaceuticals and Food have been changed to use ampersands
+            # instead of commas due to the way we're doing the mocks, change in the future
+            # probably just read from a series of mock files, would make it cleaner
+            ["14D", "1414 DEGREES LIMITED", "2018-09-12", "Capital Goods", "19592589"],
+            ["1AD", "ADALTA LIMITED", "2016-08-22", "Pharmaceuticals & Biotechnology & Life Sciences", "15709237"],
+            ["1AE", "AURORA ENERGY METALS LIMITED", "2022-05-18", "Materials", "37791912"],
+            ["1AG", "ALTERRA LIMITED", "2008-05-16", "Food & Beverage & Tobacco", "10433288"],
+            ["1MC", "MORELLA CORPORATION LIMITED", "2001-01-08", "Materials", "144141145"]
         ]
 
         # build the mock CSV data based on self.get_listed_companies_data
 
-        for i in range(0, 3):  # header
-            self.get_listed_companies_mock+= "\n"
+        self.get_listed_companies_mock += "\n"
 
         for row in self.get_listed_companies_data:
 
@@ -137,9 +140,11 @@ class CompaniesTest(unittest.TestCase):
             for company in companies:
                 company_data = self.get_listed_companies_data[i]
 
-                self.assertEqual(company["name"], company_data[0])
-                self.assertEqual(company["ticker"], company_data[1])
-                self.assertEqual(company["gics_industry"], company_data[2])
+                self.assertEqual(company["ticker"], company_data[0])
+                self.assertEqual(company["name"], company_data[1])
+                self.assertEqual(company["listing_date"], company_data[2])
+                self.assertEqual(company["gics_industry"], company_data[3])
+                self.assertEqual(company["market_cap"], company_data[4])
 
                 i += 1
 

--- a/pyasx/tests/data/securities.py
+++ b/pyasx/tests/data/securities.py
@@ -207,6 +207,11 @@ class SecuritiesTest(unittest.TestCase):
         Simple check of pulling live data
         """
 
-        security = pyasx.data.securities.get_security_info('TLSAA')
+        # The functionality for calling individual securities on tickers longer than
+        # 3 has apparently been deprecated, I have not tested with ALL securities
+        # longer than 3 chars, but from the testing I've done, it seems to hold.
+        # If this is true, then perhaps just merging the company and security API
+        # calls might make more sense.
+        security = pyasx.data.securities.get_security_info('TLS')
         self.assertTrue("ticker" in security)
         self.assertTrue(len(security))


### PR DESCRIPTION
```
The following changes since commit eb93a13267ae9fd5e52264f4430011af47e8d601:

  UPDATE .gitignore - clean file and add proper py and jetbrains rules (2022-07-18 23:35:49 +1000)

are available in the Git repository at:

  git@github.com:JohnVonNeumann/pyasx.git switch-to-new-companies-data-source

for you to fetch changes up to b5607faf21f729aaf056d06236b724b154b3c0b7:

  FIX tests/securities.py - fix testGetSecurityInfoLive() (2022-09-01 21:09:12 +1000)

----------------------------------------------------------------
JohnVonNeumann (2):
      UPDATE get_listed_companies() - update source and tests
      FIX tests/securities.py - fix testGetSecurityInfoLive()

 pyasx/config.yml               |  4 ++--
 pyasx/data/companies.py        | 15 ++++++++-------
 pyasx/tests/data/companies.py  | 23 ++++++++++++++---------
 pyasx/tests/data/securities.py |  7 ++++++-
 4 files changed, 30 insertions(+), 19 deletions(-)

diff --git a/pyasx/config.yml b/pyasx/config.yml
index 84d05f0..143296e 100644
--- a/pyasx/config.yml
+++ b/pyasx/config.yml
@@ -1,11 +1,11 @@
 ---
 
 # Endpoint providing CSV of listed companies and their tickers
-asx_companies_csv: https://www.asx.com.au/asx/research/ASXListedCompanies.csv
+asx_companies_csv: https://asx.api.markitdigital.com/asx-research/1.0/companies/directory/file
 
 # Endpoint providing XLS spreadsheet of all listed securities and their tickers
 asx_securities_tsv: https://www.asx.com.au/programs/ISIN.xls
-    # NOTE the extension is xls but the file is actuall tab separated
+    # NOTE the extension is xls but the file is actually tab separated
 
 # Endpoint to pull individual companies data
 asx_company_json: https://www.asx.com.au/asx/1/company/%s?fields=primary_share,latest_annual_reports,last_dividend,primary_share.indices
diff --git a/pyasx/data/companies.py b/pyasx/data/companies.py
index f8bbd01..4906101 100644
--- a/pyasx/data/companies.py
+++ b/pyasx/data/companies.py
@@ -48,21 +48,22 @@ def get_listed_companies():
 
         # rewind the temp stream and convert it to an iterator for csv.reader below
         temp_stream.seek(0)
-        temp_iter = iter(temp_stream.readline, '');
+        temp_iter = iter(temp_stream.readline, '')
 
-        # skip the first 3 rows of the CSV as they are header rows
-        for i in range(0, 3):
-            next(temp_iter)
+        # skip the first row of the CSV as it is a header row
+        next(temp_iter)
 
         # read the stream back in & parse out the company details from each row
         for row in csv.reader(temp_iter):
 
-            name, ticker, gics = row
+            ticker, name, listing_date, gics, market_cap = row
 
             all_listed_companies.append({
-                'name': name,
                 'ticker': ticker,
-                'gics_industry': gics
+                'name': name,
+                'listing_date': listing_date,
+                'gics_industry': gics,
+                'market_cap': market_cap
             })
 
     return all_listed_companies
diff --git a/pyasx/tests/data/companies.py b/pyasx/tests/data/companies.py
index dd00d0c..69beecd 100644
--- a/pyasx/tests/data/companies.py
+++ b/pyasx/tests/data/companies.py
@@ -32,16 +32,19 @@ class CompaniesTest(unittest.TestCase):
 
         self.get_listed_companies_data = [
             # just the first ones from the file to test with
-            [ "MOQ LIMITED", "MOQ", "Software & Services" ],
-            [ "1-PAGE LIMITED", "1PG", "Software & Services" ],
-            [ "1300 SMILES LIMITED", "ONT", "Health Care Equipment & Services" ],
-            [ "1ST GROUP LIMITED", "1ST", "Health Care Equipment & Services" ],
+            # the fields for Pharmaceuticals and Food have been changed to use ampersands
+            # instead of commas due to the way we're doing the mocks, change in the future
+            # probably just read from a series of mock files, would make it cleaner
+            ["14D", "1414 DEGREES LIMITED", "2018-09-12", "Capital Goods", "19592589"],
+            ["1AD", "ADALTA LIMITED", "2016-08-22", "Pharmaceuticals & Biotechnology & Life Sciences", "15709237"],
+            ["1AE", "AURORA ENERGY METALS LIMITED", "2022-05-18", "Materials", "37791912"],
+            ["1AG", "ALTERRA LIMITED", "2008-05-16", "Food & Beverage & Tobacco", "10433288"],
+            ["1MC", "MORELLA CORPORATION LIMITED", "2001-01-08", "Materials", "144141145"]
         ]
 
         # build the mock CSV data based on self.get_listed_companies_data
 
-        for i in range(0, 3):  # header
-            self.get_listed_companies_mock+= "\n"
+        self.get_listed_companies_mock += "\n"
 
         for row in self.get_listed_companies_data:
 
@@ -137,9 +140,11 @@ class CompaniesTest(unittest.TestCase):
             for company in companies:
                 company_data = self.get_listed_companies_data[i]
 
-                self.assertEqual(company["name"], company_data[0])
-                self.assertEqual(company["ticker"], company_data[1])
-                self.assertEqual(company["gics_industry"], company_data[2])
+                self.assertEqual(company["ticker"], company_data[0])
+                self.assertEqual(company["name"], company_data[1])
+                self.assertEqual(company["listing_date"], company_data[2])
+                self.assertEqual(company["gics_industry"], company_data[3])
+                self.assertEqual(company["market_cap"], company_data[4])
 
                 i += 1
 
diff --git a/pyasx/tests/data/securities.py b/pyasx/tests/data/securities.py
index e2d33e1..a25d7cb 100644
--- a/pyasx/tests/data/securities.py
+++ b/pyasx/tests/data/securities.py
@@ -207,6 +207,11 @@ class SecuritiesTest(unittest.TestCase):
         Simple check of pulling live data
         """
 
-        security = pyasx.data.securities.get_security_info('TLSAA')
+        # The functionality for calling individual securities on tickers longer than
+        # 3 has apparently been deprecated, I have not tested with ALL securities
+        # longer than 3 chars, but from the testing I've done, it seems to hold.
+        # If this is true, then perhaps just merging the company and security API
+        # calls might make more sense.
+        security = pyasx.data.securities.get_security_info('TLS')
         self.assertTrue("ticker" in security)
         self.assertTrue(len(security))
```
